### PR TITLE
Update metadata to support Gnome 44 and 45

### DIFF
--- a/notification-filter@asynclink.org/metadata.json
+++ b/notification-filter@asynclink.org/metadata.json
@@ -6,9 +6,11 @@
     "40",
     "41",
     "42",
-    "43"
+    "43",
+    "44",
+    "45"
   ],
   "url": "https://github.com/spybug/NotifyFilter-GnomeExtension",
   "uuid": "notification-filter@asynclink.org",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
The extension worked for me on Fedora 38 with Gnome 44.6, so just adding a supported version seems to be enough.

Not sure about support for 45, but @eindgebruiker might test that.