### PR TITLE
Update metadata for gnome 46 support.

### DIFF
--- a/notification-filter@asynclink.org/metadata.json
+++ b/notification-filter@asynclink.org/metadata.json
@@ -3,7 +3,8 @@
   "name": "Notification Filter",
   "settings-schema": "org.gnome.shell.extensions.notification-filter",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/spybug/NotifyFilter-GnomeExtension",
   "uuid": "notification-filter@asynclink.org",


### PR DESCRIPTION
I've tested with the Fedora 40 beta and everything seems fine, so all that's required is to add gnome 46 to the supported versions in the metadata.