### PR TITLE
Gnome 48/49 updates and fixes

### DIFF
--- a/notification-filter@asynclink.org/extension.js
+++ b/notification-filter@asynclink.org/extension.js
@@ -110,10 +110,14 @@ let customUpdateState = function() {
  * Returns whether the given stringToTest contains the filter. If use_regex is true than a Regular Expression is used for the match.
  */
 function testMatch(stringToTest, filter, use_regex = false) {
-  // Check to see if regex support is enabled, and if so use it.
-  if (use_regex) {
-    const regex = new RegExp(filter);
-    return regex.test(stringToTest);
+  if( typeof stringToTest == 'string' || stringToTest instanceof String ) {
+    // Check to see if regex support is enabled, and if so use it.
+    if (use_regex) {
+      const regex = new RegExp(filter);
+      return regex.test(stringToTest);
+    }
+    return stringToTest.includes(filter);
+  } else {
+    return false;
   }
-  return stringToTest.includes(filter);
 }

--- a/notification-filter@asynclink.org/extension.js
+++ b/notification-filter@asynclink.org/extension.js
@@ -63,7 +63,17 @@ let customUpdateState = function() {
   // Filter out notification queue based on settings.
   this._notificationQueue = this._notificationQueue.filter((notification) => {
     const notificationTitle = notification.title;
-    const notificationBody = notification.bannerBodyText;
+
+    // At some point Gnome changed the body text property from "bannerBodyText" to just "body"
+    // (probably Gnome 46?), so let's check to see if the old property exists, if it does use it,
+    // otherwise use the new one.
+    let notificationBody = '';
+    if( notification.bannerBodyText !== undefined ) {
+      notificationBody = notification.bannerBodyText;
+    } else {
+      notificationBody = notification.body;
+    }
+
     let filterNotification = false;
 
     // Loop through user specified FilterSettings to see if notification matches any.

--- a/notification-filter@asynclink.org/metadata.json
+++ b/notification-filter@asynclink.org/metadata.json
@@ -3,7 +3,7 @@
   "name": "Notification Filter",
   "settings-schema": "org.gnome.shell.extensions.notification-filter",
   "shell-version": [
-    "45", "46", "47"
+    "45", "46", "47", "48", "49"
   ],
   "url": "https://github.com/spybug/NotifyFilter-GnomeExtension",
   "uuid": "notification-filter@asynclink.org",


### PR DESCRIPTION
Update the metadata for newer versions of gnome and resolve an issue with notification body text.